### PR TITLE
Replace deprecated `govuk-typography-responsive` mixin

### DIFF
--- a/x-govuk/code/_code.scss
+++ b/x-govuk/code/_code.scss
@@ -25,7 +25,7 @@ $x-govuk-code-color: #d13118;
 }
 
 .x-govuk-code--block {
-  @include govuk-typography-responsive(16, $override-line-height: 1.4);
+  @include govuk-font(16, $line-height: 1.4);
   @include govuk-responsive-margin(4, "bottom");
   background-color: govuk-colour("light-grey");
   overflow: auto;


### PR DESCRIPTION
`govuk-typography-responsive` was deprecated in GOV.UK Frontend v5.1.0 in favour of the more clearly named `govuk-font`.

If this PR is accepted, will release as v0.4.0, which is classed as a breaking release.