### PR TITLE
Use neutral namespace for code highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ md.render('```js\nconsole.log(\'Hello, World!\')\n```')
 Will output:
 
 ```html
-<pre class="x-govuk-code x-govuk-code--block" tabindex="0">
-  <code class="x-govuk-code__language--js">
-    <span class="x-govuk-code__variable">console</span>.<span class="x-govuk-code__title">log</span>(<span class="x-govuk-code__string">'Hello, World!'</span>)
+<pre class="app-code app-code--block" tabindex="0">
+  <code class="app-code__language--js">
+    <span class="app-code__variable">console</span>.<span class="app-code__title">log</span>(<span class="app-code__string">'Hello, World!'</span>)
   </code>
 </pre>
 ```

--- a/src/_index.scss
+++ b/src/_index.scss
@@ -4,13 +4,13 @@
 // https://github.com/alphagov/govuk-design-system/blob/main/src/stylesheets/main.scss
 $_code-color: #d13118;
 
-.x-govuk-code--inline,
-.x-govuk-code--block {
+.app-code--inline,
+.app-code--block {
   font-family: ui-monospace, monospace;
   -webkit-font-smoothing: auto;
 }
 
-.x-govuk-code--inline {
+.app-code--inline {
   background-color: govuk-colour("light-grey");
   color: $_code-color;
   font-size: 0.875em;
@@ -26,7 +26,7 @@ $_code-color: #d13118;
   }
 }
 
-.x-govuk-code--block {
+.app-code--block {
   @include govuk-font(16, $line-height: 1.4);
   @include govuk-responsive-margin(4, "bottom");
   background-color: govuk-colour("light-grey");
@@ -58,88 +58,88 @@ $_code-color: #d13118;
   }
 }
 
-.x-govuk-code__comment,
-.x-govuk-code__quote {
+.app-code__comment,
+.app-code__quote {
   color: govuk-tint(govuk-colour("dark-grey"), 30);
   font-style: italic;
 }
 
-.x-govuk-code__keyword,
-.x-govuk-code__selector-tag,
-.x-govuk-code__subst {
+.app-code__keyword,
+.app-code__selector-tag,
+.app-code__subst {
   color: govuk-colour("black");
   font-weight: bold;
 }
 
-.x-govuk-code__number,
-.x-govuk-code__literal,
-.x-govuk-code__variable,
-.x-govuk-code__template-variable,
-.x-govuk-code__tag .x-govuk-code__attr {
+.app-code__number,
+.app-code__literal,
+.app-code__variable,
+.app-code__template-variable,
+.app-code__tag .app-code__attr {
   color: govuk-colour("green");
 }
 
-.x-govuk-code__string,
-.x-govuk-code__doctag {
+.app-code__string,
+.app-code__doctag {
   color: govuk-colour("red");
 }
 
-.x-govuk-code__title,
-.x-govuk-code__section,
-.x-govuk-code__selector-id {
+.app-code__title,
+.app-code__section,
+.app-code__selector-id {
   color: govuk-colour("bright-purple");
   font-weight: bold;
 }
 
-.x-govuk-code__subst {
+.app-code__subst {
   font-weight: normal;
 }
 
-.x-govuk-code__type,
-.x-govuk-code__class .x-govuk-code__title {
+.app-code__type,
+.app-code__class .app-code__title {
   color: govuk-colour("light-purple");
   font-weight: bold;
 }
 
-.x-govuk-code__tag,
-.x-govuk-code__name,
-.x-govuk-code__attribute {
+.app-code__tag,
+.app-code__name,
+.app-code__attribute {
   color: govuk-colour("dark-blue");
   font-weight: normal;
 }
 
-.x-govuk-code__regexp,
-.x-govuk-code__link {
+.app-code__regexp,
+.app-code__link {
   color: govuk-colour("green");
 }
 
-.x-govuk-code__symbol,
-.x-govuk-code__bullet {
+.app-code__symbol,
+.app-code__bullet {
   color: govuk-colour("purple");
 }
 
-.x-govuk-code__builtin,
-.x-govuk-code__builtin-name {
+.app-code__builtin,
+.app-code__builtin-name {
   color: govuk-colour("blue");
 }
 
-.x-govuk-code__meta {
+.app-code__meta {
   color: govuk-colour("dark-grey");
   font-weight: bold;
 }
 
-.x-govuk-code__deletion {
+.app-code__deletion {
   background: govuk-tint(govuk-colour("red"), 80);
 }
 
-.x-govuk-code__addition {
+.app-code__addition {
   background: govuk-tint(govuk-colour("green"), 80);
 }
 
-.x-govuk-code__emphasis {
+.app-code__emphasis {
   font-style: italic;
 }
 
-.x-govuk-code__strong {
+.app-code__strong {
   font-weight: bold;
 }

--- a/src/brands.js
+++ b/src/brands.js
@@ -5,7 +5,7 @@ export const brands = {
     rules: {
       blockquote_open: 'govuk-inset-text govuk-!-margin-left-0',
       code_block: 'govuk-inset-text govuk-!-margin-left-0',
-      code_inline: 'x-govuk-code x-govuk-code--inline',
+      code_inline: 'app-code app-code--inline',
       paragraph_open: 'govuk-body',
       link_open: 'govuk-link',
       bullet_list_open: 'govuk-list govuk-list--bullet',
@@ -25,7 +25,7 @@ export const brands = {
     rules: {
       blockquote_open: 'nhsuk-inset-text nhsuk-u-margin-left-0',
       code_block: 'nhsuk-inset-text nhsuk-u-margin-left-0',
-      code_inline: 'x-govuk-code x-govuk-code--inline',
+      code_inline: 'app-code app-code--inline',
       paragraph_open: 'nhsuk-body',
       link_open: 'nhsuk-link',
       bullet_list_open: 'nhsuk-list nhsuk-list--bullet',

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -1,6 +1,6 @@
 import highlightJs from 'highlight.js'
 
-highlightJs.configure({ classPrefix: 'x-govuk-code__' })
+highlightJs.configure({ classPrefix: 'app-code__' })
 
 export default function (string, language) {
   if (language) {
@@ -11,9 +11,9 @@ export default function (string, language) {
     } else {
       code = highlightJs.highlightAuto(string).value
     }
-    return `<pre class="x-govuk-code x-govuk-code--block x-govuk-code__language--${language}" tabindex="0"><code>${code}</code></pre>\n`
+    return `<pre class="app-code app-code--block app-code__language--${language}" tabindex="0"><code>${code}</code></pre>\n`
   }
 
   // No language found, so render as plain text
-  return `<pre class="x-govuk-code x-govuk-code--block" tabindex="0">${string}</pre>\n`
+  return `<pre class="app-code app-code--block" tabindex="0">${string}</pre>\n`
 }


### PR DESCRIPTION
If code generated by this project appears in GOV.UK or NHS.UK projects, `app-*` tends to be the favoured namespace. Given there are no blessed styles for either project yet, let’s maintain this usage.